### PR TITLE
pytest-parallel-exit-fix

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -180,6 +180,10 @@ class SafeNumber(object):
         with self._lock:
             return int(self._val.value) == i
 
+    def __bool__(self):
+        return not self.__eq__(0)
+    __nonzero__=__bool__
+
     @property
     def value(self):
         return int(self._val.value)


### PR DESCRIPTION
This [line](https://github.com/pytest-dev/pytest/blob/f02dbaf97fb6be74a439a56128b76872490d0581/src/_pytest/main.py#L217) assumes that ```session.testfailed``` has a bool method which returns false if the value of ```session.testfailed``` is 0. With the changes in https://github.com/browsertron/pytest-parallel/pull/13 that is no longer the case, since session.testfailed is now an object, and the default semantics of bool for objects are whether it is ```None``` or not. https://docs.python.org/2/reference/datamodel.html#object.__nonzero__

As a consequence, pytest-parallel now always returns 1 as an exit code when run with more than one worker. 
This change prevents that from happening by adding a __bool__ method for python3 and a __nonzero__ method for python2.