### PR TITLE
Fix test_concurrent.py flakiness

### DIFF
--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -7,6 +7,8 @@ def test_concurrent_fixture(testdir):
         @pytest.fixture
         def driver(request):
             fn_name = request.function.__name__
+            if fn_name == 'test_1':
+                time.sleep(.05)
             print_('before sleep', fn_name)
             time.sleep(.1)
             print_('after sleep', fn_name)


### PR DESCRIPTION
The concurrent tests of this repo depended on the order that pytest ran the tests. Unfortunately, the ordering isn't guaranteed, so the test was flaky. This adds a delay to ensure the order of the `print()` calls is guaranteed.