### PR TITLE
Call queue.task_done always

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -78,11 +78,13 @@ class ThreadWorker(threading.Thread):
                 time.sleep(.1)
                 continue
             item = self.session.items[index]
-            run_test(self.session, item, None)
             try:
-                self.queue.task_done()
-            except ConnectionRefusedError:
-                pass
+                run_test(self.session, item, None)
+            finally:
+                try:
+                    self.queue.task_done()
+                except ConnectionRefusedError:
+                    pass
 
 
 @pytest.mark.trylast


### PR DESCRIPTION
This is needed with exceptions inside of `run_test` to not make
pytest-parallel hang then.

Fixes hanging `tests/test_general.py::test_environ_shim[cli_args1]`
test.