### PR TITLE
Reraise (internal) exceptions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,6 +5,7 @@ name = "pypi"
 
 [packages]
 pytest = ">=3.0.0"
+tblib = "*"
 
 [dev-packages]
 pylint = "*"

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -78,11 +78,13 @@ class ThreadWorker(threading.Thread):
                 time.sleep(.1)
                 continue
             item = self.session.items[index]
-            run_test(self.session, item, None)
             try:
-                self.queue.task_done()
-            except ConnectionRefusedError:
-                pass
+                run_test(self.session, item, None)
+            finally:
+                try:
+                    self.queue.task_done()
+                except ConnectionRefusedError:
+                    pass
 
 
 @pytest.mark.trylast

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -53,22 +53,26 @@ def run_test(session, item, nextitem):
         raise session.Interrupted(session.shouldstop)
 
 
-def process_with_threads(queue, session, tests_per_worker):
+def process_with_threads(queue, session, tests_per_worker, errors):
     threads = []
     for _ in range(tests_per_worker):
-        thread = ThreadWorker(queue, session)
+        thread = ThreadWorker(queue, session, errors)
         thread.start()
         threads.append(thread)
     [t.join() for t in threads]
 
 
 class ThreadWorker(threading.Thread):
-    def __init__(self, queue, session):
+    def __init__(self, queue, session, errors):
         threading.Thread.__init__(self)
         self.queue = queue
         self.session = session
+        self.errors = errors
 
     def run(self):
+        from tblib import pickling_support
+
+        pickling_support.install()
         while True:
             try:
                 index = self.queue.get_nowait()
@@ -80,6 +84,10 @@ class ThreadWorker(threading.Thread):
             item = self.session.items[index]
             try:
                 run_test(self.session, item, None)
+            except BaseException:
+                import pickle
+                import sys
+                self.errors.put(pickle.dumps(sys.exc_info()))
             finally:
                 try:
                     self.queue.task_done()
@@ -326,12 +334,13 @@ class ParallelRunner(object):
                       tests_per_worker, test_noun, thread_noun))
 
         queue = Queue.Queue() if self.workers == 1 else self._manager.Queue()
+        errors = Queue.Queue() if self.workers == 1 else self._manager.Queue()
 
         for i in range(len(session.items)):
             queue.put(i)
 
         if self.workers == 1:
-            process_with_threads(queue, session, tests_per_worker)
+            process_with_threads(queue, session, tests_per_worker, errors)
             return True
 
         # Ensure testsfailed is process-safe
@@ -340,10 +349,22 @@ class ParallelRunner(object):
         processes = []
         for _ in range(self.workers):
             process = Process(target=process_with_threads,
-                              args=(queue, session, tests_per_worker))
+                              args=(queue, session, tests_per_worker, errors))
             process.start()
             processes.append(process)
         [p.join() for p in processes]
         queue.join()
+
+        if not errors.empty():
+            import six
+            import pickle
+
+            exc = RuntimeError("pytest-parallel got {} errors, raising the first.".format(
+                errors.qsize()
+            ))
+            err = pickle.loads(errors.get())
+            err[1].__traceback__ = err[2]
+
+            six.raise_from(exc, err[1])
 
         return True

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ deps =
   pytest>=3.0
   pytest-html>=1.19.0
   six>=1.11.0
+  tblib
 commands = pytest {posargs:tests}
 
 [testenv:flake8]


### PR DESCRIPTION
Includes https://github.com/browsertron/pytest-parallel/pull/47 for now (direct rebase failed).

This should make the test suite not hang anymore.