### PR TITLE
Set reporter._show_progress_info = False

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -232,6 +232,7 @@ class ParallelRunner(object):
 
         # prevent mangling the output
         reporter.showfspath = False
+        reporter._show_progress_info = False
 
         # get the number of workers
         workers = parse_config(config, 'workers')


### PR DESCRIPTION
This works around https://github.com/browsertron/pytest-parallel/issues/46.

It also seems to be good in general, since this also mangles the output
(and appears to be off (far behind in percentage) for when it appears etc).