### PR TITLE
SafeNumber: add __ge__, __le__, __repr__

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -178,9 +178,17 @@ class SafeNumber(object):
             self._val.value += i
             return self
 
+    def __ge__(self, i):
+        with self._lock:
+            return int(self._val.value) >= i
+
     def __gt__(self, i):
         with self._lock:
             return int(self._val.value) > i
+
+    def __le__(self, i):
+        with self._lock:
+            return int(self._val.value) <= i
 
     def __lt__(self, i):
         with self._lock:
@@ -200,6 +208,10 @@ class SafeNumber(object):
     def __str__(self):
         with self._lock:
             return str(self._val.value)
+
+    def __repr__(self):
+        with self._lock:
+            return repr(self._val.value)
 
     @property
     def value(self):

--- a/tests/test_safenumber.py
+++ b/tests/test_safenumber.py
@@ -1,0 +1,22 @@
+import multiprocessing as mp
+
+from pytest_parallel import SafeNumber
+
+
+def test_SafeNumber():
+    manager = mp.Manager()
+
+    nr = SafeNumber(manager)
+    assert isinstance(nr, SafeNumber)
+    assert not nr
+    assert nr == 0
+
+    assert nr + 1 == 1
+    nr += 1
+    assert isinstance(nr, SafeNumber)
+    assert nr == 1
+    assert nr >= 1
+    assert nr <= 1
+    assert nr
+    assert repr(nr) == '1'
+    assert str(nr) == '1'


### PR DESCRIPTION
Fixes https://github.com/browsertron/pytest-parallel/issues/37.