### PR TITLE
Implement pytest's default pytest_runtestloop

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -318,10 +318,17 @@ class ParallelRunner(object):
         os.environ = ThreadLocalEnviron(os.environ)
 
     def pytest_runtestloop(self, session):
-        if session.testsfailed and \
-                not session.config.option.continue_on_collection_errors:
+        if (
+            session.testsfailed
+            and not session.config.option.continue_on_collection_errors
+        ):
             raise session.Interrupted(
-                "%d errors during collection" % session.testsfailed)
+                "%d error%s during collection"
+                % (session.testsfailed, "s" if session.testsfailed != 1 else "")
+            )
+
+        if session.config.option.collectonly:
+            return True
 
         # get the number of tests per worker
         tests_per_worker = parse_config(session.config, 'tests_per_worker')

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -318,6 +318,11 @@ class ParallelRunner(object):
         os.environ = ThreadLocalEnviron(os.environ)
 
     def pytest_runtestloop(self, session):
+        if session.testsfailed and \
+                not session.config.option.continue_on_collection_errors:
+            raise session.Interrupted(
+                "%d errors during collection" % session.testsfailed)
+
         # get the number of tests per worker
         tests_per_worker = parse_config(session.config, 'tests_per_worker')
         try:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -241,3 +241,21 @@ def test_collection_error(testdir, cli_args):
     result.assert_outcomes(error=1)
     # Expect error code 2 (Interrupted), which is returned on collection error.
     assert result.ret == 2
+
+
+@pytest.mark.parametrize('cli_args', [
+  [],
+  ['--workers=2'],
+  ['--tests-per-worker=2']
+])
+def test_collection_collectonly(testdir, cli_args):
+    testdir.makepyfile("def test(): pass")
+    result = testdir.runpytest("--collect-only", *cli_args)
+    result.stdout.fnmatch_lines([
+        "collected 1 item",
+        "<Module test_collection_collectonly.py>",
+        "  <Function test>",
+        "*= no tests ran in *",
+    ])
+    result.assert_outcomes()
+    assert result.ret == 0

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -223,3 +223,21 @@ def test_pytest_html(testdir, cli_args):
         assert re.search('1 failed', html) is not None
         assert re.search('passed results-table-row', html) is not None
         assert re.search('failed results-table-row', html) is not None
+
+
+@pytest.mark.parametrize('cli_args', [
+  [],
+  ['--workers=2'],
+  ['--tests-per-worker=2']
+])
+def test_collection_error(testdir, cli_args):
+    testdir.makepyfile(first_file_test="""
+        def test_1():
+            assert 1 == 1
+    """, second_file_test="""
+        raise Exception('Failed to load test file')
+    """)
+    result = testdir.runpytest(*cli_args)
+    result.assert_outcomes(error=1)
+    # Expect error code 2 (Interrupted), which is returned on collection error.
+    assert result.ret == 2

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,6 @@ commands = pytest {posargs:tests}
 skip_install = true
 deps = flake8
 commands = flake8 pytest_parallel setup.py tests tasks.py
+
+[flake8]
+max-line-length = 88


### PR DESCRIPTION
Includes https://github.com/browsertron/pytest-parallel/pull/45.