### PR TITLE
tests: skip test_pytest_html if not installed

### DIFF
--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -205,6 +205,7 @@ def test_multiple_failures(testdir, cli_args):
   ['--tests-per-worker=2']
 ])
 def test_pytest_html(testdir, cli_args):
+    pytest.importorskip("pytest_html")
     report = testdir.tmpdir.join('report.html')
     testdir.makepyfile("""
         def test_1():


### PR DESCRIPTION
This is for convenience, and it being tested on CI should be covered via
coverage etc.