### PR TITLE
Update the environ shim to be compatible with Python 3.9

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -113,15 +113,26 @@ def pytest_configure(config):
 
 class ThreadLocalEnviron(os._Environ):
     def __init__(self, env):
-        super().__init__(
-            env._data,
-            env.encodekey,
-            env.decodekey,
-            env.encodevalue,
-            env.decodevalue,
-            env.putenv,
-            env.unsetenv
-        )
+        if sys.version_info >= (3, 9):
+            super().__init__(
+                env._data,
+                env.encodekey,
+                env.decodekey,
+                env.encodevalue,
+                env.decodevalue,
+            )
+            self.putenv = os.putenv
+            self.unsetenv = os.unsetenv
+        else:
+            super().__init__(
+                env._data,
+                env.encodekey,
+                env.decodekey,
+                env.encodevalue,
+                env.decodevalue,
+                env.putenv,
+                env.unsetenv
+            )
         if hasattr(env, 'thread_store'):
             self.thread_store = env.thread_store
         else:

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -69,7 +69,6 @@ def test_sanity_async_double(testdir):
 
 
 @pytest.mark.parametrize('cli_args', [
-  [],
   ['--workers=2'],
   ['--tests-per-worker=2']
 ])

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
   py36
   py37
   py38
+  py39
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ envlist =
 
 [testenv]
 deps =
-  pytest>=3.0
+  pytest>=3.0,<6.0
   pytest-html>=1.19.0
   six>=1.11.0
   tblib


### PR DESCRIPTION
The `os.putenv()` and `os.unsetenv()` are always available starting in Python
3.9, removing the need for special handling in the `os._Environ` mapping:
https://github.com/python/cpython/commit/b8d1262e8afe7b907b4a394a191739571092acdb

To get the tests in working order I had to limit them to run with `pytest<6.0`. I have not investigated why the tests can not run with more recent `pytest` versions.

To my knowledge this is the only outstanding issue for Python 3.9 support. Fixes #89