### PR TITLE
Let auto worker count be set via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Put simply, `pytest-xdist` does parallelism while `pytest-parallel` does paralle
 
 ## Options
 
-* `workers` (optional) - max workers (aka processes) to start. Can be a **positive integer or `auto`** which uses one worker per core. **Defaults to 1**.
+* `workers` (optional) - max workers (aka processes) to start. Can be a **positive integer or `auto`** which uses one worker per core or the number specified by the environment variable `PYTEST_AUTO_WORKERS`, if set. **Defaults to 1**.
 * `tests-per-worker` (optional) - max concurrent tests per worker. Can be a **positive integer or `auto`** which evenly divides tests among the workers up to 50 concurrent tests. **Defaults to 1**.
 
 ## Examples

--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -205,7 +205,7 @@ class ParallelRunner(object):
         workers = parse_config(config, 'workers')
         try:
             if workers == 'auto':
-                workers = os.cpu_count() or 1
+                workers = int(os.getenv("PYTEST_AUTO_WORKERS", os.cpu_count() or 1))
             elif workers:
                 workers = int(workers)
             else:


### PR DESCRIPTION
This PR addresses #110, enabling the auto worker count to be set via the `PYTEST_AUTO_WORKERS` environment variable. If this variable is not set and `auto` workers is chosen, the current behavior remains.