### PR TITLE
Update pytest decoration

### DIFF
--- a/pytest_parallel/__init__.py
+++ b/pytest_parallel/__init__.py
@@ -218,7 +218,7 @@ class ParallelRunner(object):
 
         self.workers = workers
 
-    @pytest.mark.tryfirst
+    @pytest.hookimpl(tryfirst=True)
     def pytest_sessionstart(self, session):
         # make the session threadsafe
         _pytest.runner.SetupState = ThreadLocalSetupState


### PR DESCRIPTION
Running on python `3.12.3` with pytest `8.2.1` I got this message:

```
PytestDeprecationWarning: The hookimpl ParallelRunner.pytest_sessionstart uses old-style configuration options (marks or attributes).
Please use the pytest.hookimpl(tryfirst=True) decorator instead
 to configure the hooks.
 See https://docs.pytest.org/en/latest/deprecations.html#configuring-hook-specs-impls-using-markers
  @pytest.mark.tryfirst
```